### PR TITLE
Add atomic positions to MDL V3000 files

### DIFF
--- a/src/Molecule/Molecule.js
+++ b/src/Molecule/Molecule.js
@@ -48,11 +48,15 @@ exports._molImpl = helpers => molecule =>
 
     for (const atom of atoms)
     {
+        const atomIndex = moleculeAtoms.length;
         moleculeAtoms.push(
          chemlibMolecule.addAtom(
                 helpers.atomicNumber(helpers.chemicalSymbol(atom))
             )
         );
+        chemlibMolecule.setAtomX(atomIndex, helpers.positionX(atom));
+        chemlibMolecule.setAtomY(atomIndex, helpers.positionY(atom));
+        chemlibMolecule.setAtomZ(atomIndex, helpers.positionZ(atom));
     }
 
     for (const bond of bonds)

--- a/src/Molecule/Molecule.purs
+++ b/src/Molecule/Molecule.purs
@@ -84,10 +84,14 @@ type Helpers =
     , bonds :: Validated.Molecule -> Array Validated.MoleculeBond
 
     , chemicalSymbol
-        :: Validated.MoleculeAtom -> ChemicalSymbol.ChemicalSymbol
+        :: Validated.MoleculeAtom
+        -> ChemicalSymbol.ChemicalSymbol
 
     , atomicNumber :: ChemicalSymbol.ChemicalSymbol -> Int
-    , id :: Validated.MoleculeAtom -> Int
+    , id           :: Validated.MoleculeAtom -> Int
+    , positionX    :: Validated.MoleculeAtom -> Number
+    , positionY    :: Validated.MoleculeAtom -> Number
+    , positionZ    :: Validated.MoleculeAtom -> Number
     , atom1 :: Validated.MoleculeBond -> Validated.MoleculeAtom
     , atom2 :: Validated.MoleculeBond -> Validated.MoleculeAtom
     , order :: Validated.MoleculeBond -> Int
@@ -103,6 +107,9 @@ _smiles' = _smilesImpl
     , chemicalSymbol: Validated.chemicalSymbol
     , atomicNumber: ChemicalSymbol.atomicNumber
     , id: Validated.id
+    , positionX: Position.x <<< Validated.position
+    , positionY: Position.y <<< Validated.position
+    , positionZ: Position.z <<< Validated.position
     , atom1: Validated.atom1
     , atom2: Validated.atom2
     , order: Validated.order
@@ -129,6 +136,9 @@ molString (Molecule { _molecule }) = _molImpl
     , chemicalSymbol: Validated.chemicalSymbol
     , atomicNumber: ChemicalSymbol.atomicNumber
     , id: Validated.id
+    , positionX: Position.x <<< Validated.position
+    , positionY: Position.y <<< Validated.position
+    , positionZ: Position.z <<< Validated.position
     , atom1: Validated.atom1
     , atom2: Validated.atom2
     , order: Validated.order


### PR DESCRIPTION
Related Issues: #32 

When the user writes a MDL V3000 file the atomic positions of the
molecule will be correctly written. The issue was that the
`chemlibMolecule` was not having the atomic positions set.