### PR TITLE
Replace ascending descending

### DIFF
--- a/src/Page/MoleculeBrowser/SortButton/components/styled/form.tsx
+++ b/src/Page/MoleculeBrowser/SortButton/components/styled/form.tsx
@@ -96,12 +96,12 @@ const Radio: React.FunctionComponent<RadioProps>
                 <FormControlLabel
                     value={'ascending'}
                     control={<RadioBase />}
-                    label={'Ascending'}
+                    label={'Smallest First'}
                 />
                 <FormControlLabel
                     value={'descending'}
                     control={<RadioBase />}
-                    label={'Descending'}
+                    label={'Largest First'}
                 />
             </RadioGroup>
         </Grid>


### PR DESCRIPTION
Related Issues: #33

Replaces "Ascending" with "Smallest First" and "Descending" with
"Largest First". I think this is easier to understand.
