### PR TITLE
Sort drop down list

### DIFF
--- a/src/Page/MoleculeBrowser/SortedAll.purs
+++ b/src/Page/MoleculeBrowser/SortedAll.purs
@@ -16,6 +16,7 @@ module Page.MoleculeBrowser.SortedAll
 
 import Prelude
 import Data.Array as Array
+import Data.String as String
 import PageKind (PageKind)
 import PageKind as PageKind
 import SortType (SortType)
@@ -196,7 +197,7 @@ props :: forall a r.  ActionCreators a r -> Model -> Props a
 props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
     Props.AllViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 
@@ -261,7 +262,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
     Props.ThreeDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 
@@ -324,7 +325,7 @@ props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
     Props.TwoDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 
@@ -387,7 +388,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: false } =
     Props.NoViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 

--- a/src/Page/MoleculeBrowser/SortedBuildingBlocks.purs
+++ b/src/Page/MoleculeBrowser/SortedBuildingBlocks.purs
@@ -16,6 +16,7 @@ module Page.MoleculeBrowser.SortedBuildingBlocks
 
 import Prelude
 import Data.Array as Array
+import Data.String as String
 import PageKind (PageKind)
 import PageKind as PageKind
 import SortType (SortType)
@@ -196,7 +197,7 @@ props :: forall a r.  ActionCreators a r -> Model -> Props a
 props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
     Props.AllViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 
@@ -261,7 +262,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
     Props.ThreeDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 
@@ -324,7 +325,7 @@ props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
     Props.TwoDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 
@@ -387,7 +388,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: false } =
     Props.NoViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 

--- a/src/Page/MoleculeBrowser/SortedConstructedMolecules.purs
+++ b/src/Page/MoleculeBrowser/SortedConstructedMolecules.purs
@@ -16,6 +16,7 @@ module Page.MoleculeBrowser.SortedConstructedMolecules
 
 import Prelude
 import Data.Array as Array
+import Data.String as String
 import PageKind (PageKind)
 import PageKind as PageKind
 import SortType (SortType)
@@ -197,7 +198,7 @@ props :: forall a r.  ActionCreators a r -> Model -> Props a
 props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
     Props.AllViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 
@@ -262,7 +263,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
     Props.ThreeDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 
@@ -325,7 +326,7 @@ props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
     Props.TwoDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 
@@ -389,7 +390,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: false } =
     Props.NoViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (onSetSorted actionCreators model)
             (onSetUnsorted actionCreators model)
 

--- a/src/Page/MoleculeBrowser/UnsortedAll.purs
+++ b/src/Page/MoleculeBrowser/UnsortedAll.purs
@@ -15,6 +15,7 @@ module Page.MoleculeBrowser.UnsortedAll
 
 import Prelude
 import Data.Array as Array
+import Data.String as String
 import PageKind (PageKind)
 import PageKind as PageKind
 import SortType (SortType)
@@ -171,7 +172,7 @@ props :: forall a r.  ActionCreators a r -> Model -> Props a
 props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
     Props.AllViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 
@@ -237,7 +238,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
     Props.ThreeDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 
@@ -300,7 +301,7 @@ props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
     Props.TwoDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 
@@ -363,7 +364,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: false } =
     Props.NoViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 

--- a/src/Page/MoleculeBrowser/UnsortedBuildingBlocks.purs
+++ b/src/Page/MoleculeBrowser/UnsortedBuildingBlocks.purs
@@ -15,6 +15,7 @@ module Page.MoleculeBrowser.UnsortedBuildingBlocks
 
 import Prelude
 import Data.Array as Array
+import Data.String as String
 import PageKind (PageKind)
 import PageKind as PageKind
 import SortType (SortType)
@@ -171,7 +172,7 @@ props :: forall a r.  ActionCreators a r -> Model -> Props a
 props actionCreators model@{ twoDViewer: true, threeDViewer: true} =
     Props.AllViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 
@@ -236,7 +237,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: true} =
 props actionCreators model@{ twoDViewer: false, threeDViewer: true} =
     Props.ThreeDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 
@@ -299,7 +300,7 @@ props actionCreators model@{ twoDViewer: false, threeDViewer: true} =
 props actionCreators model@{ twoDViewer: true, threeDViewer: false} =
     Props.TwoDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 
@@ -362,7 +363,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: false} =
 props actionCreators model@{ twoDViewer: false, threeDViewer: false} =
     Props.NoViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 

--- a/src/Page/MoleculeBrowser/UnsortedConstructedMolecules.purs
+++ b/src/Page/MoleculeBrowser/UnsortedConstructedMolecules.purs
@@ -15,6 +15,7 @@ module Page.MoleculeBrowser.UnsortedConstructedMolecules
 
 import Prelude
 import Data.Array as Array
+import Data.String as String
 import PageKind (PageKind)
 import PageKind as PageKind
 import SortType (SortType)
@@ -174,7 +175,7 @@ props :: forall a r.  ActionCreators a r -> Model -> Props a
 props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
     Props.AllViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 
@@ -239,7 +240,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
     Props.ThreeDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 
@@ -302,7 +303,7 @@ props actionCreators model@{ twoDViewer: false, threeDViewer: true } =
 props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
     Props.TwoDViewer $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 
@@ -365,7 +366,7 @@ props actionCreators model@{ twoDViewer: true, threeDViewer: false } =
 props actionCreators model@{ twoDViewer: false, threeDViewer: false } =
     Props.NoViewers $
         { sortButton: SortButton.props
-            model.valueCollections
+            (Array.sortWith String.toLower model.valueCollections)
             (setSorted actionCreators model)
             (setUnsorted actionCreators model)
 


### PR DESCRIPTION
Related Issues: #25

The drop down list for sorting collections will now be sorted
alphabetically so that it is easier to navigate. The sorting is case
insensitive.